### PR TITLE
Fix absence of comma

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ NeoBundle 'lambdalisue/vim-gista-ctrlp', {
 " neobundle.vim (Lazy)
 NeoBundle 'lambdalisue/vim-gista-ctrlp', {
     \ 'depends': [
-    \   'lambdalisue/vim-gista'
+    \   'lambdalisue/vim-gista',
     \   'ctrlpvim/ctrlp.vim'
     \ ],
     \ 'on_cmd': 'CtrlPGista',


### PR DESCRIPTION
README.md の neobundle.vim (Lazy) のカンマが抜けていました。
